### PR TITLE
Fail faster and more clearly on error

### DIFF
--- a/src/install-edm-linux.sh
+++ b/src/install-edm-linux.sh
@@ -27,7 +27,7 @@ install_edm() {
     local EDM_INSTALLER_PATH="${DOWNLOAD_DIR}/${EDM_PACKAGE}"
 
     if [ ! -e "$EDM_INSTALLER_PATH" ]; then
-        curl -o "$EDM_INSTALLER_PATH" -L "https://package-data.enthought.com/edm/rh6_x86_64/${EDM_MAJOR_MINOR}/${EDM_PACKAGE}"
+        curl --fail --show-error -o "$EDM_INSTALLER_PATH" -L "https://package-data.enthought.com/edm/rh6_x86_64/${EDM_MAJOR_MINOR}/${EDM_PACKAGE}"
     fi
 
     bash "$EDM_INSTALLER_PATH" -b -p "${HOME}/edm"

--- a/src/install-edm-osx.sh
+++ b/src/install-edm-osx.sh
@@ -26,7 +26,7 @@ install_edm() {
     local EDM_INSTALLER_PATH="${DOWNLOAD_DIR}/${EDM_PACKAGE}"
 
     if [ ! -e "$EDM_INSTALLER_PATH" ]; then
-        curl -o "$EDM_INSTALLER_PATH" -L "https://package-data.enthought.com/edm/osx_x86_64/${EDM_MAJOR_MINOR}/${EDM_PACKAGE}"
+        curl --fail --show-error -o "$EDM_INSTALLER_PATH" -L "https://package-data.enthought.com/edm/osx_x86_64/${EDM_MAJOR_MINOR}/${EDM_PACKAGE}"
     fi
 
     sudo installer -pkg "$EDM_INSTALLER_PATH" -target /


### PR DESCRIPTION
Use the `--fail` argument to `curl` so that on permissions errors we get a nonzero return code. Also use `--show-error` so that we see the HTTP error code. (Note that we still won't see the detailed HTML error message in the body of the response.)

~This should close issue #3, at least for macOS and Linux.~  This doesn't close issue #3, but it does make the error a bit clearer.